### PR TITLE
Make Test::CleanNamespaces a runtime requirement

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,6 +11,9 @@ filename = t/clean-namespaces.t
 [@Author::ETHER]
 :version = 0.051
 
+[Prereqs]
+Test::CleanNamespaces = 0.15
+
 [Prereqs / DevelopRequires]
 Test::Warnings = 0
 


### PR DESCRIPTION
Steps to reproduce the problem:
- Have a fresh perl
- git clone App-nopaste 
- cpanm -n Dist::Zilla && dzil authordeps | cpanm -n
- dzil test

You'll have a test failure because Test::CleanNamespaces is not installed.

This plugin has no use when it's installed without Test::CleanNamespaces accompanied.
